### PR TITLE
Fix invalid repo value in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,6 @@
 	"minAppVersion": "0.15.0",
 	"description": "Scan java source and test code for comments then place it in md files.",
 	"author": "Gerrie Myburgh",
-	"repo": "https://github.com/gerrie-myburgh/source-scanner",
+	"repo": "gerrie-myburgh/source-scanner",
 	"isDesktopOnly": false
 }


### PR DESCRIPTION
The "repo" value in manifest.json should only contain the username and repo name, not the whole URL.

I found this when working on the Obsidian Hub, and seeing that invalid Urls would be generated for this plugin, like this: note the duplicate `https://github.com/https://github.com`.

```
https://github.com/https://github.com/gerrie-myburgh/source-scanner
```